### PR TITLE
v2.7.91

### DIFF
--- a/core/core.js
+++ b/core/core.js
@@ -14,7 +14,7 @@ var modapi_preinit = `globalThis.ModAPI ||= {};
       `;
 var freezeCallstack = `if(ModAPI.hooks.freezeCallstack){return false};`;
 const EFIConfig = {
-    ModAPIVersion: "v2.7.8", //also change in package.json
+    ModAPIVersion: "v2.7.9", //also change in package.json
     doEaglerforge: true,
     verbose: false,
     doServerExtras: false,
@@ -128,6 +128,7 @@ async function processClasses(string, parser) {
         assets.modapi_modloader = modapi_modloader;
         assets.modapi_guikit = modapi_guikit;
     }
+    _status("Running EaglerForgeInjector " + EFIConfig.ModAPIVersion);
     if (string.includes("__eaglerforgeinjector_installation_flag__")) {
         backgroundLog("Detected input containing EFI installation flag.", true);
         return alert("this file already has EaglerForge injected in it, you nonce.\nif you're trying to update, you need a vanilla file.")

--- a/core/core.js
+++ b/core/core.js
@@ -14,7 +14,7 @@ var modapi_preinit = `globalThis.ModAPI ||= {};
       `;
 var freezeCallstack = `if(ModAPI.hooks.freezeCallstack){return false};`;
 const EFIConfig = {
-    ModAPIVersion: "v2.7.9", //also change in package.json
+    ModAPIVersion: "v2.7.91", //also change in package.json
     doEaglerforge: true,
     verbose: false,
     doServerExtras: false,

--- a/core/postinit.js
+++ b/core/postinit.js
@@ -1104,10 +1104,14 @@ const modapi_postinit = "(" + (() => {
     }
 
     ModAPI.util.bootstrap = function () {
-        ModAPI.items = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.init.Items")].staticVariables, StaticProps_ProxyConf);
-        ModAPI.blocks = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.init.Blocks")].staticVariables, StaticProps_ProxyConf);
-        ModAPI.materials = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.block.material.Material")].staticVariables, StaticProps_ProxyConf);
-        ModAPI.enchantments = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.enchantment.Enchantment")].staticVariables, StaticProps_ProxyConf); //bugged on 1.12 due to more client optimisations. might need to change the optimisation intensity
+        ModAPI.items = new Proxy(ModAPI.reflect.getClassById("net.minecraft.init.Items").staticVariables, StaticProps_ProxyConf);
+        ModAPI.blocks = new Proxy(ModAPI.reflect.getClassById("net.minecraft.init.Blocks").staticVariables, StaticProps_ProxyConf);
+        ModAPI.materials = new Proxy(ModAPI.reflect.getClassById("net.minecraft.block.material.Material").staticVariables, StaticProps_ProxyConf);
+        if (ModAPI.is_1_12) {
+            ModAPI.enchantments = new Proxy(ModAPI.reflect.getClassById("net.minecraft.init.Enchantments").staticVariables, StaticProps_ProxyConf);
+        } else {
+            ModAPI.enchantments = new Proxy(ModAPI.reflect.getClassById("net.minecraft.enchantment.Enchantment").staticVariables, StaticProps_ProxyConf);
+        }
     }
 
     ModAPI.events.newEvent("bootstrap", "server");

--- a/core/postinit.js
+++ b/core/postinit.js
@@ -1094,7 +1094,7 @@ const modapi_postinit = "(" + (() => {
         ModAPI.items = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.init.Items")].staticVariables, StaticProps_ProxyConf);
         ModAPI.blocks = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.init.Blocks")].staticVariables, StaticProps_ProxyConf);
         ModAPI.materials = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.block.material.Material")].staticVariables, StaticProps_ProxyConf);
-        ModAPI.enchantments = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.enchantment.Enchantment")].staticVariables, StaticProps_ProxyConf);
+        ModAPI.enchantments = new Proxy(ModAPI.hooks._classMap[ModAPI.util.getCompiledName("net.minecraft.enchantment.Enchantment")].staticVariables, StaticProps_ProxyConf); //bugged on 1.12 due to more client optimisations. might need to change the optimisation intensity
     }
 
     ModAPI.events.newEvent("bootstrap", "server");

--- a/docs/apidoc/index.md
+++ b/docs/apidoc/index.md
@@ -79,6 +79,8 @@ The global object has the following properties:
     - More: [ArrayDocumentation](array.md)
  - `ModAPI.version: String`
     - The version of ModAPI.
+ - `ModAPI.is_1_12: Boolean`
+    - Property defining wether or not ModAPI thinks the current version is 1.12-based.
  - `ModAPI.flavour: String`
     - The flavour of ModAPI. Hardcoded to be `"injector"`.
 

--- a/examplemods/veinminer.js
+++ b/examplemods/veinminer.js
@@ -115,14 +115,11 @@
                 b.$harvestBlock = function ($theWorld, $player, $blockpos, $blockstate, $tileentity, ...args) {
                     const blockState = ModAPI.util.wrap($blockstate);
                     const player = ModAPI.util.wrap($player);
-                    console.log(blockState, player);
                     if (player.isSneaking() && !ModAPI.util.isCritical() && !(logs.includes(blockState.block.getRef()) && !axes.includes(player.inventory.mainInventory[player.inventory.currentItem]?.getCorrective()?.item?.getRef()))) {
                         ModAPI.promisify(async () => {
                             var world = ModAPI.util.wrap($theWorld);
                             var harvestCall = ModAPI.promisify(ModAPI.is_1_12 ? player.interactionManager.tryHarvestBlock : player.theItemInWorldManager.tryHarvestBlock);
-
                             const blocks = await getBlockGraph(ModAPI.util.wrap($blockpos), ModAPI.promisify(world.getBlockState), b);
-                            console.log(blocks);
                             for (let i = 0; i < blocks.length; i++) {
                                 await harvestCall(blocks[i].getRef());
                             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eaglerforgeinjector",
-  "version": "2.7.9",
+  "version": "2.7.91",
   "description": "Advanced modding API injector for unminified, unobfuscated, unsigned eaglercraft builds.",
   "main": "node.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eaglerforgeinjector",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "description": "Advanced modding API injector for unminified, unobfuscated, unsigned eaglercraft builds.",
   "main": "node.js",
   "directories": {


### PR DESCRIPTION
- Fixed some arrays in 1.12 being converted into `NonNullList`s, ModAPI automatically proxies these back into arrays
- Fixed accessing constants from `ModAPI.blocks`, `ModAPI.items`, and `ModAPI.materials` requiring keys to be uppercase. Keys are now automatically converted to uppercase in 1.12 (use lowercase at all times for easier cross-version compatibility, basically)
  - ModAPI.enchantments is currently broken
  - edit: nvm i fixed it :)
- `ModAPI.promisify()` now logs an error when being called with a non-function
- Veinminer mod updated for 1.12 support